### PR TITLE
Corrected spelling of "Received"

### DIFF
--- a/ex1b/stats.awk
+++ b/ex1b/stats.awk
@@ -14,7 +14,7 @@ BEGIN{
         }
         else if(event == "r")
         {
-            totalRecieved++;
+            totalReceived++;
         }
         else if(event == "d")
         {


### PR DESCRIPTION
Total number of packets received was being printed as 0.
When I closely looked into the code, i found the difference in spelling while calculating packets received and while printing. So I have updated the spelling.